### PR TITLE
update Dockerfile. Part of issue #17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY ./requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt
 
 # everything around odfuzz to be runnable in container
-RUN mkdir ODfuzz
-COPY . ODfuzz/
-WORKDIR /ODfuzz
+RUN mkdir /odfuzz
+COPY . /odfuzz/
+WORKDIR /odfuzz
 RUN python3 setup.py install


### PR DESCRIPTION
This version is better structured for docker layer caching, so it is quicker to build new image after just code change. From previous version however there is increase of  image size from 290MB to 490MB.

AFAIK this is suitable for now, with focus more on development speed.  I would like to lower the overal size together with basing it not on alpine:3.8 (without python) but on python:3.6-alpine or similar (and install just mongodb to it) - old version removed the stuff after copy of files and installation of odfuzz requirements.txt, making the layer caching not used at all.

Tested locally that the image is can be built and odfuzz is executable inside the container.