### PR TITLE
Check if a path of a certificate was specified

### DIFF
--- a/config/fuzzer/config.yaml
+++ b/config/fuzzer/config.yaml
@@ -20,7 +20,7 @@ dispatcher:
         # path. 
         cert_install_path: false
         # A file path where the HTTPS certificate is stored.
-        cert_file_path: 
+        cert_file_path: ''
 
     # A number of asynchronous requests which will be sent to a server via dispatcher
     # at the same time.

--- a/odfuzz/config.py
+++ b/odfuzz/config.py
@@ -40,7 +40,9 @@ class DispatcherConfig:
 
     @property
     def has_certificate(self):
-        return bool(self._certificate)
+        if self._certificate:
+            return bool(self._cert_file_path)
+        return False
 
     @property
     def cert_install_path(self):


### PR DESCRIPTION
A status of a certificate was not determined correctly. Before
this commit, the property method has_certificate() used to
return True even if the certificate was not declared. The
exception TypeError (stat: path should be string, bytes,
os.PathLike or integer, not NoneType) was raised while the
fuzzer was trying to check if a path to the certificate
is a valid file.

https://github.com/SAP/odfuzz/blob/184660b47b2e17838b39922cc17e40aa2304a985/odfuzz/fuzzer.py#L1170-L1172