### PR TITLE
Update the generator for edm_single

### DIFF
--- a/odfuzz/generators.py
+++ b/odfuzz/generators.py
@@ -50,7 +50,7 @@ class EdmGenerator:
 
     @staticmethod
     def edm_single():
-        return '{0:.7f}'.format(random.uniform(-10000000000, 10000000000)) + 'f'
+        return '{}f'.format(round(random.uniform(1.18e-20, 3.40e+20), 7))
 
     @staticmethod
     def edm_guid():


### PR DESCRIPTION
The type Edm.Single should not hold a negative number.
A maximum and a minimum possible value was adjusted
according to the definition of the type. Instead of
e-38 and e+38, it is used e-20 and e+20, respectively.

https://www.odata.org/documentation/odata-version-2-0/overview/