### PR TITLE
Fix the generator for edm_double

### DIFF
--- a/odfuzz/fuzzer.py
+++ b/odfuzz/fuzzer.py
@@ -1221,13 +1221,23 @@ def build_filter_string(filter_data):
 
 def replace_forbidden_characters(parts):
     for data in parts:
-        if data['operand'].startswith('\''):
-            data['operand'] = '\'' + replace_special_characters(data['operand'][1:-1]) + '\''
         if 'params' in data:
+            # replace special characters within function's parameters
             if data['params']:
                 for index, param in enumerate(data['params']):
-                    if param.startswith('\''):
-                        data['params'][index] = '\'' + replace_special_characters(param[1:-1]) + '\''
+                    replace_part_characters(data['params'], index)
+        else:
+            replace_part_characters(data, 'operand')
+
+
+def replace_part_characters(data, key):
+    if data[key].startswith('\''):
+        # Replace special characters within a string
+        data[key] = '\'' + replace_special_characters(data[key][1:-1]) + '\''
+    else:
+        # Replace special characters within doubles, or other data types
+        # which are not enclosed with a separate pair of single quotes
+        data[key] = replace_special_characters(data[key])
 
 
 def replace_special_characters(replacing_string):

--- a/odfuzz/generators.py
+++ b/odfuzz/generators.py
@@ -46,7 +46,7 @@ class EdmGenerator:
 
     @staticmethod
     def edm_double():
-        return str(round(random.uniform(-1.79e+30, 1.79e+30), 15)) + 'd'
+        return '{}d'.format(round(random.uniform(2.23e-40, 1.19e+40), 15))
 
     @staticmethod
     def edm_single():

--- a/odfuzz/monkey.py
+++ b/odfuzz/monkey.py
@@ -118,6 +118,8 @@ def patch_proprty_generator(entity_set_name, proprty, restrictions):
         proprty.generate = EdmGenerator.edm_time
     elif proprty_type == 'Edm.Binary':
         proprty.generate = EdmGenerator.edm_binary
+    elif proprty_type == 'Edm.Double':
+        proprty.generate = EdmGenerator.edm_double
     elif proprty_type.startswith('Edm.Int'):
         if proprty_type.endswith('16'):
             proprty.generate = EdmGenerator.edm_int16


### PR DESCRIPTION
Values of the type Edm.Double should not be negative according
to the documentation. The generator was updated along with the
function which replaces special characters in a URI. The special
characters were replaced only in operands of type Edm.String.

This commit closes #1.