### PR TITLE
Fix #24

### DIFF
--- a/odfuzz/config.py
+++ b/odfuzz/config.py
@@ -10,8 +10,7 @@ from odfuzz.exceptions import ConfigParserError
 
 class FuzzerConfig:
     def __init__(self, config):
-        self._sap_client = config.get('sap_client', SAP_CLIENT)
-        self._sap_client = os.getenv(ENV_SAP_CLIENT)
+        self._sap_client = os.getenv(ENV_SAP_CLIENT, config.get('sap_client', SAP_CLIENT))
         #overwrite if ENV variable exists - https://github.com/SAP/odfuzz/issues/24
 
         self._data_format = config.get('data_format', DATA_FORMAT)

--- a/odfuzz/config.py
+++ b/odfuzz/config.py
@@ -1,15 +1,19 @@
 """This module contains classes for fetching and parsing basic configurations."""
 
 import yaml
+import os
 
 from odfuzz.constants import CERTIFICATE_PATH, ASYNC_REQUESTS_NUM, FUZZER_CONFIG_PATH, \
-    SAP_CLIENT, DATA_FORMAT, URLS_PER_PROPERTY
+    SAP_CLIENT, DATA_FORMAT, URLS_PER_PROPERTY, ENV_SAP_CLIENT
 from odfuzz.exceptions import ConfigParserError
 
 
 class FuzzerConfig:
     def __init__(self, config):
         self._sap_client = config.get('sap_client', SAP_CLIENT)
+        self._sap_client = os.getenv(ENV_SAP_CLIENT)
+        #overwrite if ENV variable exists - https://github.com/SAP/odfuzz/issues/24
+
         self._data_format = config.get('data_format', DATA_FORMAT)
         self._urls_per_property = config.get('urls_per_property', URLS_PER_PROPERTY)
 

--- a/odfuzz/config.py
+++ b/odfuzz/config.py
@@ -67,15 +67,15 @@ class Config:
 
     @staticmethod
     def init_from(config_file):
-        config_dict = Config.raw_from(config_file)
+        config_dict = Config._raw_from(config_file)
         if not config_dict:
-            config_dict = Config.raw_from(FUZZER_CONFIG_PATH)
+            config_dict = Config._raw_from(FUZZER_CONFIG_PATH)
 
         Config.fuzzer = FuzzerConfig(config_dict.get('fuzzer') or {})
         Config.dispatcher = DispatcherConfig(config_dict.get('dispatcher') or {})
 
     @staticmethod
-    def raw_from(config_file):
+    def _raw_from(config_file):
         try:
             with open(config_file) as stream:
                 config_dict = yaml.safe_load(stream)

--- a/odfuzz/constants.py
+++ b/odfuzz/constants.py
@@ -34,8 +34,11 @@ MONGODB_NAME = 'odfuzz'
 # used for mounting adapters in the module `requests` (this may be located right in Dispatcher)
 ACCESS_PROTOCOL = 'https://'
 # used in Dispatcher (fuzzer.py) to obtain SAP login from environmental variables
+# TODO this should probably be used in one place only (config.py) and not scattered + rename with prefix ODFUZZ_
 ENV_USERNAME = 'SAP_USERNAME'
 ENV_PASSWORD = 'SAP_PASSWORD'
+# used for overwriting the sap-client in CI env, when currently the config.yml is mandatory to be loaded with its defaults
+ENV_SAP_CLIENT = 'ODFUZZ_SAP_CLIENT'
 
 # names of restrictions which are used for searching for keywords; these constants are also used in the module fuzzer.py
 # for creating dictionary which is going to be saved to the database - these constants are truly global, so the user


### PR DESCRIPTION
Introduce environment variable ODFUZZ_SAP_CLIENT for possibility of overwriting currently hardcoded load of config.yml  - which should be used as example however without it, odfuzz not start.

This is inteded to be a workaround solution for current issue (in code, new environment variable is intended to stay) and followup should be in #25