### PR TITLE
[DO NOT MERGE] Fix Edm.Guid mutator

### DIFF
--- a/odfuzz/mutators.py
+++ b/odfuzz/mutators.py
@@ -184,13 +184,14 @@ class GuidMutator:
 
     @staticmethod
     def replace_char(string_guid):
-        without_dashes = string_guid
-        index = round(random.random() * (len(string_guid) - 1))
+        # get the proper index to the string array by skipping the prefix "guid'"
+        # and trimming the last single quote enclosing the GUUID part
+        index = round(random.random() * (len(string_guid) - 2 - 5)) + 5
         if index in GuidMutator.GUID_DASH_INDEXES:
             index -= 1
         rand_hex_char = HEX_BINARY[round(random.random() * (len(HEX_BINARY) - 1))]
-        without_dashes = ''.join([without_dashes[:index], rand_hex_char, without_dashes[index + 1:]])
-        return without_dashes
+        mutated_guid = ''.join([string_guid[:index], rand_hex_char, string_guid[index + 1:]])
+        return mutated_guid
 
 
 class BooleanMutator:


### PR DESCRIPTION
This commit should prevent undesirable replacements of immutable characters within a Guid string. Before this commit, the following code snippet raises an error:

```python
from odfuzz.mutators import GuidMutator
while True:
    guid = GuidMutator.replace_char("guid'dddddddd-dddd-dddd-dddd-dddddddddddd'")
    if not guid.startswith("guid'") or not guid.endswith("'"):
        raise RuntimeError("oopsie")
```