### PR TITLE
Print a full stack trace when an error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix extra single quote in URL for datetime
 - Pin install dependencies for deterministic installations
 - Use the new signal handler interface after update to latest Gevent library 20.5.0
-
-### Added
-
 - Print error messages, which cause the fuzzer to stop, to stdout
 
 ## [0.13.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix Edm.Guid mutator 
 - Fix extra single quote in URL for datetime
-- Pinned install dependencies for deterministic installations
+- Pin install dependencies for deterministic installations
 - Use the new signal handler interface after update to latest Gevent library 20.5.0
+
+### Added
+
+- Print error messages, which cause the fuzzer to stop, to stdout
 
 ## [0.13.1]
 

--- a/odfuzz/odfuzz.py
+++ b/odfuzz/odfuzz.py
@@ -6,6 +6,7 @@ import sys
 import signal
 import logging
 import gevent
+import traceback
 
 from datetime import datetime
 
@@ -86,6 +87,10 @@ def run_fuzzer(bind, parsed_arguments, collection_name):
         sys.exit(1)
     except gevent.Timeout:
         signal_handler(collection_name)
+    except Exception:
+        logging.error(traceback.format_exc())
+        print(traceback.format_exc())
+        sys.exit(1)
 
 
 def signal_handler(db_collection_name):


### PR DESCRIPTION
When an unhandled error occurs, the fuzzer logs the error and ends without any useful exit message. This commit enables the fuzzer to print exception information to the standard output stream.