### PR TITLE
DispatchedBuilder tuple fix

### DIFF
--- a/odfuzz/entities.py
+++ b/odfuzz/entities.py
@@ -189,7 +189,7 @@ class FirstTouch:
         non_addressable_entity = SingleEntity(entity_set)
         queryable_entity = non_addressable_entity.generate_accessible_entity()
 
-        response = self._dispatcher.get(queryable_entity.path + '?sap-client=' + Config.fuzzer.sap_client)
+        response = self._dispatcher.get(queryable_entity[0].path + '?sap-client=' + Config.fuzzer.sap_client)
         if response.status_code == requests.codes.not_implemented:
             self._restrictions.add_exclude_restriction(entity_set.name, GLOBAL_ENTITY)
 


### PR DESCRIPTION
DispatchedBuilder failed for version 0.14a1 and above due to tuples of uri and body being returned instead of just uri, from several functions(because of PUT/POST implementation).

```
root: 140068620915672 - 12:22:41 - ERROR: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/odfuzz-0.14a3-py3.6.egg/odfuzz/odfuzz.py", line 84, in run_fuzzer
    gevent.with_timeout(parsed_arguments.timeout, manager.start)
  File "/usr/lib/python3.6/site-packages/gevent-20.5.0-py3.6-linux-x86_64.egg/gevent/timeout.py", line 375, in with_timeout
    return function(*args, **kwds)
  File "/usr/lib/python3.6/site-packages/odfuzz-0.14a3-py3.6.egg/odfuzz/fuzzer.py", line 63, in start
    entities = self.build_entities()
  File "/usr/lib/python3.6/site-packages/odfuzz-0.14a3-py3.6.egg/odfuzz/fuzzer.py", line 85, in build_entities
    return builder.build()
  File "/usr/lib/python3.6/site-packages/odfuzz-0.14a3-py3.6.egg/odfuzz/entities.py", line 62, in build
    restrictions = self._first_touch.analyze(entity_set)
  File "/usr/lib/python3.6/site-packages/odfuzz-0.14a3-py3.6.egg/odfuzz/entities.py", line 180, in analyze
    self.check_empty_entity(entity_set)
  File "/usr/lib/python3.6/site-packages/odfuzz-0.14a3-py3.6.egg/odfuzz/entities.py", line 192, in check_empty_entity
    response = self._dispatcher.get(queryable_entity.path + '?sap-client=' + Config.fuzzer.sap_client)
AttributeError: 'tuple' object has no attribute 'path
```