### PR TITLE
Tests: make test_generators.py idempotent

### DIFF
--- a/odfuzz/encoders.py
+++ b/odfuzz/encoders.py
@@ -11,6 +11,10 @@ class EncoderMixin:
     def _encode_string(cls, value):
         return cls._encode(value)
 
+    @classmethod
+    def _reset(cls):
+        cls._encode = encode_string if Config.fuzzer.use_encoder else lambda x: x
+
 
 class DecoderMixin:
     _decode = decode_string if Config.fuzzer.use_encoder else lambda x: x

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,4 +1,5 @@
 import random
+import pytest
 
 from collections import namedtuple
 
@@ -8,6 +9,12 @@ from odfuzz.encoders import encode_string
 StringPropertyMock = namedtuple('StringPropertyMock', 'max_length')
 StringNonNegativeMock = namedtuple('StringNonNegativeMock',['max_length','non_negative'])
 DecimalMock = namedtuple('DecimalMock', ['precision','scale'])
+
+@pytest.fixture(autouse=True, scope="module")
+def teardown_module():
+    #setup part of the fixture
+    yield None #control back to the test instance
+    RandomGenerator._reset() #teardown part of the fixture
 
 
 def test_string_generator_with_encoder():


### PR DESCRIPTION
This is ugly hack to already ugly code (too many globla variables and static/class methods). By adding reset() method to EncoderMixin, there is ability to set the default/init state of encoders in test teardown fixture, so other tests using the RandomGenerator would not be affected by persistant state, set up by last test in the module by pushing some function to RandomGenerator._encode property.

What did not work, even tho apparent:

Save the current functionin the property (even with deepcopy) to temp variable and set back in the test end. By some collision of pytest magic and @classmethod decorator, the tests would fail, because the "previous" encoder, stored in the temp var, is used in the generated string; even (not sure why) if the set back is after the assert line.


Goal to the future:
Refactor entirely in the core library, that would have better testability by as less global state as possible.