### PR TITLE
Bugfix: DispatchedBuilder tuple

### DIFF
--- a/odfuzz/fuzzer.py
+++ b/odfuzz/fuzzer.py
@@ -262,9 +262,8 @@ class Fuzzer:
         return True
 
     def _get_single_response(self, queries):
-        query = queries[0]
         try:
-            self._get_response(query)
+            self._get_response(queries)
         except DispatcherError:
             self._handle_dispatcher_exception()
             return False


### PR DESCRIPTION
This is an extension to  #89 

Removed indexing of the tuple 'queries' to avoid indexing errors in _get_response() function

Error raised:
```
odfuzz\odfuzz\fuzzer.py", line 274, in _get_response
    query[0].response = self._dispatcher.get(query[0].query_string, timeout=REQUEST_TIMEOUT)
TypeError: 'Query' object does not support indexing
```