### PR TITLE
Exclusion list

### DIFF
--- a/odfuzz/entities.py
+++ b/odfuzz/entities.py
@@ -139,13 +139,9 @@ class DirectBuilder:
     
     def _apply_restrictions(self):
         '''Method for excluding entities and their properties as a part of RestrictionsGroup'''
-        list_of_entities = self._queryable.all()
-        excluded_entites = []
+        list_of_entities = []
 
-        for entity_set in list_of_entities:
-            if self._regex_match(entity_set._entity_set._name, None, None):
-                excluded_entites.append(entity_set)
-
+        for entity_set in self._queryable.all():
             for proprty in list(entity_set.entity_set.entity_type._properties.keys()):
                 if self._regex_match(entity_set._entity_set._name, proprty, None):
                     entity_set.entity_set.entity_type._properties.pop(proprty)
@@ -154,9 +150,8 @@ class DirectBuilder:
                 if self._regex_match(entity_set._entity_set._name, proprty, nav_proprties):
                     entity_set.entity_set.entity_type._nav_properties.pop(nav_proprties)
 
-        for entity_set in excluded_entites:
-            if entity_set in list_of_entities:
-                list_of_entities.remove(entity_set)
+            if not self._regex_match(entity_set._entity_set._name, None, None):
+                list_of_entities.append(entity_set)
 
         return list_of_entities
     

--- a/odfuzz/entities.py
+++ b/odfuzz/entities.py
@@ -120,7 +120,10 @@ class DirectBuilder:
         Config.fuzzer.sap_vendor_enabled = sap_vendor_enabled
 
         # Ugly but necessary so the field exists for classes and methods in fuzzer.py using the Config.
-        # Normally initialized in the middle of CLI calls, but in this case this is the first entrypoint and Config does not exists yet.
+        # Normally initialized in the middle of CLI calls, but in this case this is the first entrypoint and Config does not exists yet.     
+    def set_restrictions(self, restrictions):
+        self._restrictions = restrictions
+
     def build(self):
         # call just once on fuzzer process start
         data_model = self._get_data_model()
@@ -135,7 +138,7 @@ class DirectBuilder:
         return self._apply_restrictions()
     
     def _apply_restrictions(self):
-        #Method for excluding entities and their properties as a part of exclusion_list
+        '''Method for excluding entities and their properties as a part of RestrictionsGroup'''
         list_of_entities = self._queryable.all()
         excluded_entites = []
 
@@ -158,7 +161,7 @@ class DirectBuilder:
         return list_of_entities
     
     def _regex_match(self, entity_name, proprty_name, nav_proprty_name):
-        #Method used to check for entities and properties which are to be excluded
+        '''Method used to check for entities and properties which are to be excluded'''
         restrictions = self._restrictions.excluded_options()
         for entity in restrictions:
             properties = restrictions[entity]["Properties"]

--- a/odfuzz/fuzzer.py
+++ b/odfuzz/fuzzer.py
@@ -9,7 +9,6 @@ import gevent
 import requests
 import requests.adapters
 import json
-import re
 
 from copy import deepcopy
 from collections import namedtuple
@@ -346,29 +345,19 @@ class Queryable:
         self._logger = logger
         self._async_requests_num = async_requests_num
 
-    def generate_query(self, restrictions):
+    def generate_query(self):
         accessible_entity, body_key_pairs = self._queryable.get_accessible_entity()
         query = Query(accessible_entity)
         self.generate_options(query)
-        body = self.generate_body(accessible_entity, body_key_pairs, restrictions)
+        body = self.generate_body(accessible_entity, body_key_pairs)
         Stats.tests_num += 1
         # TODO REFACATOR - example HARDCODED USAGE OF STATS trough import - for DirectBuilder apparently not relevant since results files are out of scope of such usage
         return query,body
-
-    def regex_match(self, entity_name, proprty_name, restrictions):
-        for entity in restrictions:
-            if len(restrictions[entity]) > 0 and re.match(entity, entity_name) != None:
-                for properties in restrictions[entity]:
-                    if re.match(properties, proprty_name) != None:
-                        return True
-        return False
     
-    def generate_put_post_body(self, accessible_entity, body_key_pairs, restrictions):
+    def generate_put_post_body(self, accessible_entity, body_key_pairs):
         body={}
         properties = accessible_entity.entity_set.entity_type._properties
         for prprty in properties.values():
-            if self.regex_match(accessible_entity.entity_set.name, prprty.name, restrictions):
-                continue
             #checking if the property exists in generated body_key_pairs. If yes, then the body equivalent value is used
             if prprty.name in body_key_pairs:
                 generated_body = body_key_pairs[prprty.name]
@@ -382,14 +371,12 @@ class Queryable:
         return body
 
 
-    def generate_merge_body(self, accessible_entity, body_key_pairs, restrictions):
+    def generate_merge_body(self, accessible_entity, body_key_pairs):
         body = {}
         properties = {}
         #if the property is a key, then its omitted from the body
         for proprty in accessible_entity.entity_set.entity_type._properties:
             if proprty not in body_key_pairs:
-                if self.regex_match(accessible_entity.entity_set.name, proprty, restrictions):
-                    continue
                 properties[proprty] = accessible_entity.entity_set.entity_type._properties[proprty]
         #if no non-key properties exist, then empty body returned
         if len(properties) == 0:
@@ -408,14 +395,15 @@ class Queryable:
             #property removed from the properties dict to avoid creating duplicates
             properties.pop(selected_property._name)
         return body
+        
 
-    def generate_body(self,accessible_entity,body_key_pairs,restrictions):
+    def generate_body(self,accessible_entity,body_key_pairs):
         #body initialised as empty dict. For GET and DELETE the body would remain empty
         body={}
         if Config.fuzzer.http_method_enabled == "PUT" or Config.fuzzer.http_method_enabled == "POST":
-            body = self.generate_put_post_body(accessible_entity, body_key_pairs,restrictions)
+            body = self.generate_put_post_body(accessible_entity, body_key_pairs)
         elif Config.fuzzer.http_method_enabled == "MERGE":
-            body = self.generate_merge_body(accessible_entity, body_key_pairs,restrictions)
+            body = self.generate_merge_body(accessible_entity, body_key_pairs)
         elif Config.fuzzer.http_method_enabled == "GET" or Config.fuzzer.http_method_enabled == "DELETE":
             pass
         else:
@@ -655,8 +643,8 @@ class SingleQueryable(Queryable):
     """
     used when fuzzer is not triggered with async option, generates URLs  by one
     """
-    def generate(self, restrictions):
-        query,body = self.generate_query(restrictions)
+    def generate(self):
+        query,body = self.generate_query()
         body = json.dumps(body)
         return [query,body]
 

--- a/odfuzz/restrictions.py
+++ b/odfuzz/restrictions.py
@@ -3,22 +3,31 @@
 import yaml
 
 from odfuzz.exceptions import RestrictionsError
-from odfuzz.constants import EXCLUDE, INCLUDE, DRAFT_OBJECTS, QUERY_OPTIONS, FORBID_OPTION, VALUE
+from odfuzz.constants import EXCLUDE, INCLUDE, DRAFT_OBJECTS, QUERY_OPTIONS, FORBID_OPTION, VALUE, GLOBAL_ENTITY_SET
 
 
 class RestrictionsGroup:
     """A wrapper that holds a reference for all types of restrictions."""
 
-    def __init__(self, restrictions_file):
+    def __init__(self, restrictions_file, exclusion_dict=None):
         self._restrictions_file = restrictions_file
+        self._exclusion_dict = exclusion_dict
         self._forbidden_options = []
         self._option_restrictions = {}
+        self._excluded_options = {}
 
         if self._restrictions_file:
             parsed_restrictions = self._parse_restrictions()
         else:
             parsed_restrictions = {}
         self._init_restrictions(parsed_restrictions)
+
+        if exclusion_dict:
+            modified_excluded_dict = self._build_exclusion_dict(exclusion_dict)
+            self._init_restrictions(modified_excluded_dict)
+
+    def _build_exclusion_dict(self, exclusion_dict):
+        return {EXCLUDE: exclusion_dict, INCLUDE: {}}
 
     def _parse_restrictions(self):
         try:
@@ -39,6 +48,7 @@ class RestrictionsGroup:
             self._option_restrictions[query_option] = QueryRestrictions(query_exclude_restr, query_include_restr)
 
         self._forbidden_options = exclude_restr.get(FORBID_OPTION, [])
+        self._excluded_options = exclude_restr.get(GLOBAL_ENTITY_SET, {})
         self._init_draft_objects(include_restr)
         self._init_value_objects(include_restr)
 
@@ -62,6 +72,9 @@ class RestrictionsGroup:
 
     def get(self, option_name):
         return self._option_restrictions.get(option_name)
+    
+    def excluded_options(self):
+        return self._excluded_options
 
 
 class QueryRestrictions:

--- a/tests/integration/url_generator_only/test_url_generator_only.py
+++ b/tests/integration/url_generator_only/test_url_generator_only.py
@@ -195,7 +195,7 @@ def test_method_for_exclusion_dict(method_type):
  
     #FioriDast update the Exception List
     restrictions = RestrictionsGroup(None, exclusion_dict)
-    del_builder.restrictions = restrictions
+    del_builder.set_restrictions(restrictions)
     del_entities = del_builder.build()
 
 method_types = ["GET", "POST", "MERGE", "PUT", "DELETE"]

--- a/tests/integration/url_generator_only/test_url_generator_only.py
+++ b/tests/integration/url_generator_only/test_url_generator_only.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 import random
+import os
 
 from odfuzz.restrictions import RestrictionsGroup
 from odfuzz.entities import DirectBuilder
@@ -154,3 +155,49 @@ def test_function_imports():
     function_import_list = FunctionImport.get_functionimport_list(path_to_metadata.read_bytes())
     fuzzed_fi = FunctionImport.generate_queries_for_functionimport(function_import_list[0])
     assert fuzzed_fi == "DuplicateCategory?CategoryName='%C2%AA%C2%BA%C3%92d2%C2%B5%C2%BC%E2%80%94%C3%A6Qi%C3%84%C2%BC%C2%81t%5E%C3%BD%E2%80%98l%C2%A7K%C3%99%C2%8F%E2%80%9D%C2%A7%3D%C3%AB_%C2%B2T%C3%AE%3C%C3%A8%E2%80%98J%C2%B2%24%C2%AE%C3%9C%E2%80%9Cl%C3%94b%21JZ%3C%C3%88%E2%80%99%24%E2%80%B0%C3%A9%C3%8B%C2%B1%C2%AC%C2%B7q%C3%A6%C3%94%C2%81%C2%BFP7%C2%A5%24ji%C2%BE%3C%C3%9A%C3%A7s%C3%87uN%E2%80%A2%C3%90%60%C3%98NDz%C2%AFRY%C2%8D%C2%AB%C2%A6%C2%B0%40%C3%AD%E2%80%93L%C3%9D%C3%84UF%2B%C2%B2%3CR%C3%A8%C3%A5TU%C2%B9%C5%92%C2%81%C2%AC7b%C3%8A%C3%B5l%C6%92%C2%A8%40u_%C2%B0%C2%A3%C3%94P%E2%84%A2%C2%BD%C3%AB%24%C3%BB%C3%85-%C3%84%C2%BA%C3%99%C2%BEqR%C2%BC%C3%AB%C2%B5%C2%A2J%C2%A7%C3%89%C3%94%C2%8D%C3%88'&DuplicateName='%C3%B2R%C3%8E%C2%AEA%C2%A6ja%C2%AE%C3%88qm%C2%8DyNC%C3%9A%C2%B2%C2%BBK%C2%B3%C2%AC%C2%BF%C2%B0%E2%80%A1%C3%B8%29%C3%B1%C2%B3%C2%A9%C6%92%C3%A5%C3%84%C3%84O%C3%BC%21%C5%93%C3%9Di%C3%AE0%C3%A3%C3%95%C3%92%C3%9F%C2%B9gE%7C%C2%AC%5E%C3%B6%5Dxl%C3%97%C3%8BC%5BQ%C3%AA%C2%B9L%E2%80%98%C3%97%C2%A2Z%C2%8DVu%C3%96Z%C2%AA3z%C3%AE%3E%C2%B5%C3%BD%C3%BF%C3%B0%C3%84%C3%B7%C2%A9%C2%B0%C3%A9%C3%BD%C3%8D3%2B%C3%97%E2%80%99E%C3%9F%C3%9Fb3%C2%A9'&DuplicationComment='%E2%80%9D%C3%A51r%C2%A9xo%C2%8D%28%E2%80%98%C2%B2%C2%A9%7DZ%C3%9F%C3%BE%3D%C2%B6%C3%B0%7C%C3%80%C2%BE%C3%80_%C2%A3%C2%AF%C3%A2%E2%80%A1%C2%8D%C3%B8%E2%80%93%C2%BA%C2%B0%C2%B9%C3%95%C2%B9v%C3%AF%C3%89%C3%B7%E2%80%99%C3%B7%C2%A3S%C3%99%C2%A6%C3%B7%C3%8Fq%C3%97%C3%BA%3Ee%C3%96%C2%81%C3%A5%C5%93s%C3%BC%C2%A1%C3%9B%60%3D%C3%9AX%24S%3Ez%C3%8Dn6%C3%90%C3%BDs%C2%A7Z%C3%90%C3%91%C2%AE%C3%96e%C2%9D1%E2%80%A0%C3%92Y%C3%84%C3%8F%20%C2%81m%C3%A7%C3%B0%C3%93mj%C3%8F%E2%80%99%C2%A1%C2%81%C3%98%C3%A2SPF%C3%9A%C5%92Rh%C3%B8%C3%88%C3%81%C2%8Dx%C2%A1%C2%AE%C3%92%C2%8DpM%C2%AF%C3%B3%C2%B7%C3%9B%C2%B1%C3%B7%C2%AF%C3%99T%C2%8F%C2%A9%E2%80%A1%C3%8E%C3%82%C2%B3%E2%84%A2Zz%C2%AB%C3%A3OkX%C3%A2%C3%A1Y%C3%90%C2%AA%E2%80%98%C3%8E%E2%80%9Cm%C3%99nR'&DeleteOriginal=true"
+
+#static dictionary for testing the implementation of exclusion_list
+exclusion_dict = {
+                "$ENTITY_SET$":{
+                        "Products": {
+                            "Properties":["ProductID", "ProductName"],
+                            "Nav_Properties":["Category"]
+                        },
+                        "Categories": {
+                            "Properties":[],
+                            "Nav_Properties":[]
+                        }
+                    }
+                }
+
+def test_method_for_exclusion_dict(method_type):
+    #Method used for testing the implementation of exclusion_list
+    os.environ["ODFUZZ_IGNORE_METADATA_RESTRICTIONS"] = "True"
+    path_to_metadata = Path(__file__).parent.joinpath("metadata-northwind-v2.xml")
+    metadata_file_contents = path_to_metadata.read_bytes()
+    restrictions = RestrictionsGroup(None, exclusion_dict)
+    del_builder = DirectBuilder(metadata_file_contents, restrictions, method_type)
+    del_entities = del_builder.build()
+    queryable_factory = SingleQueryable
+    queries_list = []
+    queries_list.clear()
+    
+    for queryable in del_entities:
+        entityset_urls_count = len(queryable.entity_set.entity_type.proprties())
+
+        for _ in range(entityset_urls_count):
+            q = queryable_factory(queryable, logger, 1)
+            queries,body = q.generate()
+
+            print(method_type, "\n")
+            print(queries.query_string,"\n")
+            print(body,"\n\n")
+ 
+    #FioriDast update the Exception List
+    restrictions = RestrictionsGroup(None, exclusion_dict)
+    del_builder.restrictions = restrictions
+    del_entities = del_builder.build()
+
+method_types = ["GET", "POST", "MERGE", "PUT", "DELETE"]
+for methods in method_types:
+    test_method_for_exclusion_dict(methods)

--- a/tests/integration/url_generator_only/test_url_generator_only.py
+++ b/tests/integration/url_generator_only/test_url_generator_only.py
@@ -28,15 +28,15 @@ def test_expected_integration_sample():
     entities = builder.build()
 
     ''' uncomment for code sample purposes
-    print('\n entity count: ', len(entities.all()) )
-    for x in entities.all():
+    print('\n entity count: ', len(entities) )
+    for x in entities:
         print(x.__class__.__name__, '  --  ', x.entity_set)
     print('\n--End of listing the parsed entities--')
     '''
 
     queryable_factory = SingleQueryable
 
-    for queryable in entities.all():
+    for queryable in entities:
         URL_COUNT_PER_ENTITYSET = len(queryable.entity_set.entity_type.proprties()) * 1
         #Leaving as 1 instead of default 20, so the test output is more understandable and each property has one URL generated
 
@@ -68,7 +68,7 @@ def test_direct_builder_http_get():
     get_entities , queryable_factory = builder("GET")
     queries_list = []
     queries_list.clear()
-    for queryable in get_entities.all():
+    for queryable in get_entities:
         entityset_urls_count = len(queryable.entity_set.entity_type.proprties())
         for _ in range(entityset_urls_count):
             q = queryable_factory(queryable, logger, 1)
@@ -83,7 +83,7 @@ def test_direct_builder_http_delete():
     del_entities , queryable_factory = builder("DELETE")
     queries_list = []
     queries_list.clear()
-    for queryable in del_entities.all():
+    for queryable in del_entities:
         entityset_urls_count = len(queryable.entity_set.entity_type.proprties())
         for _ in range(entityset_urls_count):
             q = queryable_factory(queryable, logger, 1)
@@ -98,7 +98,7 @@ def test_direct_builder_http_put_url():
     put_entities , queryable_factory = builder("PUT")
     queries_list = []
     queries_list.clear()
-    for queryable in put_entities.all():
+    for queryable in put_entities:
         entityset_urls_count = len(queryable.entity_set.entity_type.proprties())
         for _ in range(entityset_urls_count):
             q = queryable_factory(queryable, logger, 1)
@@ -113,7 +113,7 @@ def test_direct_builder_http_post_url():
     post_entities , queryable_factory = builder("POST")
     queries_list = []
     queries_list.clear()
-    for queryable in post_entities.all():
+    for queryable in post_entities:
         entityset_urls_count = len(queryable.entity_set.entity_type.proprties())
         for _ in range(entityset_urls_count):
             q = queryable_factory(queryable, logger, 1)
@@ -128,7 +128,7 @@ def test_direct_builder_body_generation():
     dir_entities , queryable_factory = builder("PUT")
     body_list = []
     body_list.clear()
-    for queryable in dir_entities.all():
+    for queryable in dir_entities:
         entityset_urls_count = len(queryable.entity_set.entity_type.proprties())
         for _ in range(entityset_urls_count):
             q = queryable_factory(queryable, logger, 1)
@@ -141,7 +141,7 @@ def test_direct_builder_http_merge_body():
     merge_entities , queryable_factory = builder("MERGE")
     body_list = []
     body_list.clear()
-    for queryable in merge_entities.all():
+    for queryable in merge_entities:
         entityset_urls_count = len(queryable.entity_set.entity_type.proprties())
         for _ in range(entityset_urls_count):
             q = queryable_factory(queryable, logger, 1)
@@ -170,26 +170,20 @@ exclusion_dict = {
                     }
                 }
 
-def test_method_for_exclusion_dict(method_type):
+def test_method_for_exclusion_dict():
     #Method used for testing the implementation of exclusion_list
     os.environ["ODFUZZ_IGNORE_METADATA_RESTRICTIONS"] = "True"
     path_to_metadata = Path(__file__).parent.joinpath("metadata-northwind-v2.xml")
     metadata_file_contents = path_to_metadata.read_bytes()
     restrictions = RestrictionsGroup(None, exclusion_dict)
-    del_builder = DirectBuilder(metadata_file_contents, restrictions, method_type)
+    del_builder = DirectBuilder(metadata_file_contents, restrictions, "GET")
     del_entities = del_builder.build()
-    queryable_factory = SingleQueryable
-    queries_list = []
-    queries_list.clear()
-    
+    queryable_factory = SingleQueryable    
     for queryable in del_entities:
         entityset_urls_count = len(queryable.entity_set.entity_type.proprties())
-
         for _ in range(entityset_urls_count):
             q = queryable_factory(queryable, logger, 1)
             queries,body = q.generate()
-
-            print(method_type, "\n")
             print(queries.query_string,"\n")
             print(body,"\n\n")
  
@@ -197,7 +191,3 @@ def test_method_for_exclusion_dict(method_type):
     restrictions = RestrictionsGroup(None, exclusion_dict)
     del_builder.set_restrictions(restrictions)
     del_entities = del_builder.build()
-
-method_types = ["GET", "POST", "MERGE", "PUT", "DELETE"]
-for methods in method_types:
-    test_method_for_exclusion_dict(methods)


### PR DESCRIPTION
### **#Implementing Exclusion_List** 

Exclusion List is a feature which allows you to exclude/restrict certain entities and their respective properties while generating URL payloads for entity_sets parsed by pyodata from the metadata.xml file

This feature has been implemented in the DirectBuider class of the odfuzz/entities.py file.
Two new Methods have been added to implement this feature:

1. **_apply_restrictions:** This is the method called by the build() method of the DirectBuilder class which iterates through and removes all the entities and their respective properties from the original list of parsed entity_sets.

2. **_regex_match:** This is a method called by the _apply_restrictions() method in order to check if the iterated entity or a particular property of that entity is present in the exclusion_list. The result is then passed on to the _apply_restrictions() method where the entities and properties and been removed from the original list containing all the parsed entity_sets.

The Exclusion_List is been passed as an argument to the RestrictionsGroup Class in the odfuzz/restrictions.py file, which in turn is been passed as an argument to the DirectBuilder class where we extract the list of excluded entities and properties present in the exclusion_list.

Below is an example of one of the exclusion_list containing two entity_sets: **Products and Categories** and their respective properties to be excluded while generating URL payloads by ODFuzz:

**exclusion_dict = {
                "$ENTITY_SET$":{
                        "Products": {
                            "Properties":["ProductID", "ProductName"],
                            "Nav_Properties":["Category"]
                        },
                        "Categories": {
                            "Properties":[],
                            "Nav_Properties":[]
                        }
                    }
                }**