### PR TITLE
Fixing DataType Issues Giving 400 Bad Request

### DIFF
--- a/odfuzz/generators.py
+++ b/odfuzz/generators.py
@@ -131,15 +131,15 @@ class EdmDecimal:
 class EdmDouble(EncoderMixin):
     @staticmethod
     def generate(generator_format='uri'):
-        random_double_uri = '{}d'.format(round(random.uniform(2.23e-40, 1.19e+40), 15))
-        value_uri = EdmDouble._encode_string(random_double_uri)
-        value_body = '{}'.format(round(random.uniform(2.23e-40, 1.19e+40), 15))
+        value_body = round(random.uniform(2.23e-40, 1.19e+40), 15)
+        value_uri = '{}d'.format(value_body)
+        value_uri_encoded = EdmDouble._encode_string(value_uri)
         if generator_format == 'uri':
-            return value_uri
+            return value_uri_encoded
         elif generator_format == 'body':
             return value_body
         elif generator_format == 'key':
-            return value_uri , value_body
+            return value_uri_encoded , value_body
         else:
             raise ValueError
 
@@ -202,8 +202,8 @@ class EdmInt32:
 class EdmInt64:
     @staticmethod
     def generate(generator_format='uri'):
-        value_uri = str(random.randint(-9223372036854775808, 9223372036854775807)) + 'L'
         value_body = str(random.randint(-9223372036854775808, 9223372036854775807))
+        value_uri = value_uri + 'L'
         if generator_format == 'uri':
             return value_uri
         elif generator_format == 'body':

--- a/odfuzz/generators.py
+++ b/odfuzz/generators.py
@@ -131,12 +131,15 @@ class EdmDecimal:
 class EdmDouble(EncoderMixin):
     @staticmethod
     def generate(generator_format='uri'):
-        random_double = '{}d'.format(round(random.uniform(2.23e-40, 1.19e+40), 15))
-        value = EdmDouble._encode_string(random_double)
-        if generator_format == 'uri' or generator_format == 'body':
-            return value
+        random_double_uri = '{}d'.format(round(random.uniform(2.23e-40, 1.19e+40), 15))
+        value_uri = EdmDouble._encode_string(random_double)
+        value_body = '{}'.format(round(random.uniform(2.23e-40, 1.19e+40), 15))
+        if generator_format == 'uri':
+            return value_uri
+        elif generator_format == 'body':
+            return value_body
         elif generator_format == 'key':
-            return value , value
+            return value_uri , value_body
         else:
             raise ValueError
 
@@ -199,11 +202,14 @@ class EdmInt32:
 class EdmInt64:
     @staticmethod
     def generate(generator_format='uri'):
-        value = str(random.randint(-9223372036854775808, 9223372036854775807)) + 'L'
-        if generator_format == 'uri' or generator_format == 'body':
-            return value
+        value_uri = str(random.randint(-9223372036854775808, 9223372036854775807)) + 'L'
+        value_body = str(random.randint(-9223372036854775808, 9223372036854775807))
+        if generator_format == 'uri':
+            return value_uri
+        elif generator_format == 'body':
+            return value_body
         elif generator_format == 'key':
-            return value , value
+            return value_uri , value_body
         else:
             raise ValueError
 

--- a/odfuzz/generators.py
+++ b/odfuzz/generators.py
@@ -132,7 +132,7 @@ class EdmDouble(EncoderMixin):
     @staticmethod
     def generate(generator_format='uri'):
         random_double_uri = '{}d'.format(round(random.uniform(2.23e-40, 1.19e+40), 15))
-        value_uri = EdmDouble._encode_string(random_double)
+        value_uri = EdmDouble._encode_string(random_double_uri)
         value_body = '{}'.format(round(random.uniform(2.23e-40, 1.19e+40), 15))
         if generator_format == 'uri':
             return value_uri


### PR DESCRIPTION
While fuzzing any endpoint, there were many 400 Bad Requests given as response from the endpoint.
One of the Major reasons being Type conversion errors for three different Data Types:

**Edm.Int64:** At the end of the Int64 Digit there was a Character 'L' appended which was giving the 400 errors, removed the concatenation of the character at the end of the digit and no more 400 Bad Requests were given for this particular Data Type.
Example:
**Earliar:** 9223372036854775807**L**
**Now:** 9223372036854775807

These changes have only been made for the body, the structure for Int64 remains same for the URI

**Edm.Double:** There were two changes to this Data Type.

Character Removal: A character 'd' was appended to the end of the digit which was giving the error, removed the character from the end and the 400 Bad Requests were resolved.
Example:
**Earliar:** 9.2237623764e%2b39**d**
**Now:** 9.2237623764e%2b39

URL Encoding: The Character '+'/'-' in the range (2.23e-40, 1.19e+40) for decimal was URL encoded when sent to the endpoint which was giving the 400 Bad request, the digit was encoded before creating the URL Payload, resolved the issue by sending the digit without encoding while creating the URL Payload.
Example:
**Earliar:** 9.2237623764e%**2b39**
**Now:** 9.2237623764**e+39**

These changes have only been made for the body, the structure for Double remains same for the URI